### PR TITLE
fix(effects): {dispatchByDefault: true} takes precedence over {dispatch: false}, checkAction throws unexpectedly

### DIFF
--- a/libs/effects/src/lib/effects-manager.ts
+++ b/libs/effects/src/lib/effects-manager.ts
@@ -46,7 +46,7 @@ export class EffectsManager {
       .pipe(takeUntil(this.destroyEffects$))
       .subscribe((maybeAction) => {
         if (
-          effect.config?.dispatch ||
+          effect.config?.dispatch ??
           (this.config.dispatchByDefault && checkAction(maybeAction))
         ) {
           actions.dispatch(maybeAction);

--- a/libs/effects/src/lib/effects-manager.ts
+++ b/libs/effects/src/lib/effects-manager.ts
@@ -63,12 +63,15 @@ export class EffectsManager {
   }
 }
 
-function checkAction(
-  action: Action | any
-): action is Action & Record<'type', any> {
-  if (action.type) {
+function checkAction(action: unknown): action is Action {
+  if (
+    typeof action === 'object' &&
+    action !== null &&
+    (action as Action).type
+  ) {
     return true;
   }
+
   throw new TypeError(
     'Make sure to provide a valid action type or set the option {dispatch: false}'
   );


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/effects/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #24 

## What is the new behavior?

1. `{dispatch: false}` now actually cancels a dispatch from an effect, even when `dispatchByDefault` is set to `true`
2. `checkAction` doesn't throw an unexpected error if `void` was dispatched from an effect by mistake, now it throws the expected `TypeError`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

--