### PR TITLE
fix(effects): remove throwing error from action filtering

### DIFF
--- a/libs/effects/src/lib/effects-manager.spec.ts
+++ b/libs/effects/src/lib/effects-manager.spec.ts
@@ -72,6 +72,10 @@ describe('Effects Manager', () => {
     effectsManager = initEffects();
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should register effects', () => {
     registerEffects(effectOne);
     registerEffects(effectTwo);
@@ -155,7 +159,7 @@ describe('Effects Manager', () => {
 
     effectsManager.removeAllEffects();
 
-    expect(dispatchSpy).toHaveBeenCalledTimes(4);
+    expect(dispatchSpy).toHaveBeenCalledTimes(3);
   });
 
   it('should dispatch actions from an effect when dispatch is set to true', () => {
@@ -163,6 +167,6 @@ describe('Effects Manager', () => {
 
     actions.dispatch(actionFive());
 
-    expect(dispatchSpy).toHaveBeenCalledTimes(7);
+    expect(dispatchSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/libs/effects/src/lib/effects-manager.ts
+++ b/libs/effects/src/lib/effects-manager.ts
@@ -45,16 +45,14 @@ export class EffectsManager {
     const sub = source
       .pipe(takeUntil(this.destroyEffects$))
       .subscribe((maybeActions) => {
-        const coercedMaybeActions = coerceArray(maybeActions);
-        const onlyActions = coercedMaybeActions.filter((maybeAction) =>
-          checkAction(maybeAction)
-        );
-
-        if (
-          effect.config?.dispatch ??
-          (this.config.dispatchByDefault && !!onlyActions.length)
-        ) {
-          actions.dispatch(...onlyActions);
+        if (effect.config?.dispatch ?? this.config.dispatchByDefault) {
+          const coercedMaybeActions = coerceArray(maybeActions);
+          const onlyActions = coercedMaybeActions.filter((maybeAction) =>
+            checkAction(maybeAction)
+          );
+          if (onlyActions.length) {
+            actions.dispatch(...onlyActions);
+          }
         }
       });
 
@@ -69,16 +67,10 @@ export class EffectsManager {
 }
 
 function checkAction(action: unknown): action is Action {
-  if (
+  return !!(
     typeof action === 'object' &&
     action !== null &&
     (action as Action).type
-  ) {
-    return true;
-  }
-
-  throw new TypeError(
-    'Make sure to provide a valid action type or set the option {dispatch: false}'
   );
 }
 


### PR DESCRIPTION
moved the filtering for only actions after checking if dispatching is true

removed the thrown error to fix the only actions filtering

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngneat/effects/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
closes #42 