### PR TITLE
fix(doc-typo): fix typo regarding hist directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ import { useDirectiveEffects, Actions } from '@ngneat/effects-ng';
 
 @Component({
   ...,
-  hostDirective: [useDirectiveEffects(TodosEffects)]
+  hostDirectives: [useDirectiveEffects(TodosEffects)]
 })
 export class TodosComponent {
   constructor(private actions: Actions) {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/effects/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

Renamed `hostDirective` to `hostDirectives` code example for effects-ng "Directive Effects".

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
```

## What is the current behavior?
Currently the docs example for directive effects contain a typo. The docs falsy states, that the effect should be added to `hostDirective` instead of `hostDirectives`.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #53 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
