### PR TITLE
feat(effects): export involved ts-action types

### DIFF
--- a/libs/effects/src/index.ts
+++ b/libs/effects/src/index.ts
@@ -13,7 +13,19 @@ export {
   ActionCreatorsAreNotAllowed,
   ErrorMessage,
 } from './lib/action-creator-is-not-allowed.type';
-export { action as createAction, props, payload } from 'ts-action';
+export {
+  action as createAction,
+  props,
+  payload,
+  Action,
+  ActionCreator,
+  ActionType,
+  Creator,
+  Typed,
+  NotTyped,
+  FunctionWithParametersType,
+  ParametersType,
+} from 'ts-action';
 export { ofType } from 'ts-action-operators';
 export { actionsFactory } from './lib/actions.factory';
 export { toPayload } from './lib/to-payload.operator';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/effects/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, we're using some functions from ts-action, but the types involved by these functions are not exposed if the user only installed "@ngneat/effects".

It might be ok for simple use cases, but when the user want to create some utility functions upon this library, it could be a little troublesome, as the user would have to include a whole library "ts-action" in order to have access to a few types to annotate their utility functions.

Besides, if the user choose to install "ts-action" to have access to these types, it can be also a little confusing when it comes to IDE auto-imports, because there could be multiple suggestions for the same function, e.g. `props`.

Issue Number: N/A

## What is the new behavior?

All the involved types are re-exported from "ts-action".

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
