### PR TITLE
feat(effects-ng): prefer classes from "effects" as injection tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,12 @@ export ROUTES = [
 ]
 ```
 
-The actions can be dispatched by injecting the `Actions` provider:
+The `Actions` class from `@ngneat/effects` has been injectable when using `@ngneat/effects-ng`.
+
+To dispatch an action, simply inject `Actions`:
 
 ```ts
-import { Actions } from '@ngneat/effects-ng';
+import { Actions } from '@ngneat/effects';
 
 @Component(...)
 export class AppComponent {
@@ -206,7 +208,8 @@ export class AppComponent {
 `provideDirectiveEffects()` and `EffectsDirective` serve to register effects on the `component injector` level. This means that effects will live as long as the component where effects are registered lives. Do not forget to call `provideEffectsManager` in the root providers.
 
 ```ts
-import { provideDirectiveEffects, EffectsDirective, Actions } from '@ngneat/effects-ng';
+import { Actions } from "@ngneat/effects";
+import { provideDirectiveEffects, EffectsDirective } from '@ngneat/effects-ng';
 
 @Component({
   ...,

--- a/libs/effects-ng/src/lib/actions.ts
+++ b/libs/effects-ng/src/lib/actions.ts
@@ -1,6 +1,9 @@
 import { Actions as _Actions } from '@ngneat/effects';
 import { Injectable } from '@angular/core';
 
+/**
+ * @deprecated Use `Actions` exported from `@ngneat/effects` instead.
+ */
 @Injectable({
   providedIn: 'root',
 })

--- a/libs/effects-ng/src/lib/effects-ng.module.spec.ts
+++ b/libs/effects-ng/src/lib/effects-ng.module.spec.ts
@@ -1,11 +1,16 @@
 import { Component, Injectable, NgModule } from '@angular/core';
 import { TestBed, flushMicrotasks, fakeAsync } from '@angular/core/testing';
-import { createAction, createEffect } from '@ngneat/effects';
+import {
+  Actions,
+  EffectsManager,
+  createAction,
+  createEffect,
+} from '@ngneat/effects';
 import { tap } from 'rxjs';
 import { ofType } from 'ts-action-operators';
-import { Actions } from './actions';
 import { EffectsNgModule } from './effects-ng.module';
-import { EFFECTS_PROVIDERS } from './tokens';
+import { EFFECTS_MANAGER, EFFECTS_PROVIDERS } from './tokens';
+import { Actions as _Actions } from './actions';
 import { Router, RouterModule } from '@angular/router';
 
 const spy = jest.fn();
@@ -38,6 +43,24 @@ class TodoComponent {
 describe('Effects ng module', () => {
   beforeEach(() => {
     spy.mockReset();
+  });
+
+  it('should provide the same instance for different tokens of Actions', () => {
+    TestBed.configureTestingModule({
+      imports: [EffectsNgModule.forRoot([])],
+    });
+    const actions = TestBed.inject(Actions);
+    const _actions = TestBed.inject(_Actions);
+    expect(actions === _actions).toBe(true);
+  });
+
+  it('should provide the same instance for different tokens of EffectsManager', () => {
+    TestBed.configureTestingModule({
+      imports: [EffectsNgModule.forRoot([])],
+    });
+    const effectsManager = TestBed.inject(EffectsManager);
+    const _effectsManager = TestBed.inject(EFFECTS_MANAGER);
+    expect(effectsManager === _effectsManager).toBe(true);
   });
 
   it('should provide effects one using forRoot', () => {

--- a/libs/effects-ng/src/lib/effects-ng.module.ts
+++ b/libs/effects-ng/src/lib/effects-ng.module.ts
@@ -1,13 +1,14 @@
 import { Inject, ModuleWithProviders, NgModule, Type } from '@angular/core';
 import {
+  Actions,
   actions,
   EffectsConfig,
   EffectsManager,
   initEffects,
 } from '@ngneat/effects';
-import { Actions } from './actions';
 import { EFFECTS_MANAGER, EFFECTS_PROVIDERS } from './tokens';
 import { registerEffectFromProviders } from './provide-effects';
+import { Actions as _Actions } from './actions';
 
 /**
  * @deprecated Please consider using `provideEffectManager` and `provideEffects` functions instead. This module will be
@@ -34,8 +35,16 @@ export class EffectsNgModule {
           useValue: config?.customActionsStream || actions,
         },
         {
-          provide: EFFECTS_MANAGER,
+          provide: _Actions,
+          useExisting: Actions,
+        },
+        {
+          provide: EffectsManager,
           useFactory: () => initEffects(config),
+        },
+        {
+          provide: EFFECTS_MANAGER,
+          useExisting: EffectsManager,
         },
         ...providers,
         {

--- a/libs/effects-ng/src/lib/provide-effects-manager.spec.ts
+++ b/libs/effects-ng/src/lib/provide-effects-manager.spec.ts
@@ -1,11 +1,17 @@
 import { Component, Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { createAction, createEffect } from '@ngneat/effects';
+import {
+  Actions,
+  EffectsManager,
+  createAction,
+  createEffect,
+} from '@ngneat/effects';
 import { tap, map } from 'rxjs';
 import { ofType } from 'ts-action-operators';
-import { Actions } from './actions';
 import { provideEffects } from './provide-effects';
 import { provideEffectsManager } from './provide-effects-manager';
+import { EFFECTS_MANAGER } from './tokens';
+import { Actions as _Actions } from './actions';
 
 const spy = jest.fn();
 
@@ -68,5 +74,21 @@ describe('provideEffectsManager', () => {
 
     expect((component as any).actions).toBeInstanceOf(CustomActions);
     expect(dispatchSpy).toHaveBeenCalled();
+  });
+
+  it('should provide the same instance for different tokens of the same object', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        TodoComponent,
+        provideEffects(EffectsOne),
+        provideEffectsManager(),
+      ],
+    });
+    const actions = TestBed.inject(Actions);
+    const _actions = TestBed.inject(_Actions);
+    expect(actions === _actions).toBe(true);
+    const manager = TestBed.inject(EffectsManager);
+    const _manager = TestBed.inject(EFFECTS_MANAGER);
+    expect(manager === _manager).toBe(true);
   });
 });

--- a/libs/effects-ng/src/lib/provide-effects-manager.ts
+++ b/libs/effects-ng/src/lib/provide-effects-manager.ts
@@ -1,7 +1,13 @@
 import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
-import { Actions } from './actions';
 import { EFFECTS_MANAGER } from './tokens';
-import { initEffects, EffectsConfig, actions } from '@ngneat/effects';
+import { Actions as _Actions } from './actions';
+import {
+  initEffects,
+  EffectsConfig,
+  actions,
+  Actions,
+  EffectsManager,
+} from '@ngneat/effects';
 
 /**
  * Must be called at the root level.
@@ -19,8 +25,16 @@ export function provideEffectsManager(
       useValue: customActionsStream,
     },
     {
-      provide: EFFECTS_MANAGER,
+      provide: _Actions,
+      useExisting: Actions,
+    },
+    {
+      provide: EffectsManager,
       useValue: manager,
+    },
+    {
+      provide: EFFECTS_MANAGER,
+      useExisting: EffectsManager,
     },
   ]);
 }

--- a/libs/effects-ng/src/lib/provide-effects.spec.ts
+++ b/libs/effects-ng/src/lib/provide-effects.spec.ts
@@ -1,9 +1,8 @@
 import { Component, Injectable } from '@angular/core';
 import { TestBed, flushMicrotasks, fakeAsync } from '@angular/core/testing';
-import { createAction, createEffect } from '@ngneat/effects';
+import { Actions, createAction, createEffect } from '@ngneat/effects';
 import { tap } from 'rxjs';
 import { ofType } from 'ts-action-operators';
-import { Actions } from './actions';
 import { provideEffects } from './provide-effects';
 import { provideEffectsManager } from './provide-effects-manager';
 import { Routes, provideRouter, Router } from '@angular/router';

--- a/libs/effects-ng/src/lib/provide-effects.ts
+++ b/libs/effects-ng/src/lib/provide-effects.ts
@@ -5,7 +5,6 @@ import {
   makeEnvironmentProviders,
   EnvironmentProviders,
 } from '@angular/core';
-import { EFFECTS_MANAGER } from './tokens';
 import { getEffectPropsMap } from './utils';
 import { Effect, EffectsManager } from '@ngneat/effects';
 import {
@@ -27,7 +26,7 @@ export function provideEffects(
       provide: ENVIRONMENT_INITIALIZER,
       multi: true,
       useValue: () => {
-        const manager = inject(EFFECTS_MANAGER, { optional: true });
+        const manager = inject(EffectsManager, { optional: true });
 
         if (!manager) {
           throw new TypeError(

--- a/libs/effects-ng/src/lib/tokens.ts
+++ b/libs/effects-ng/src/lib/tokens.ts
@@ -4,6 +4,10 @@ import { EffectsManager } from '@ngneat/effects';
 export const EFFECTS_PROVIDERS = new InjectionToken<Type<any>[]>(
   '@ngneat/effects Effects providers'
 );
+
+/**
+ * @deprecated Use the {@link EffectsManager} class from `@ngneat/effects` instead.
+ */
 export const EFFECTS_MANAGER = new InjectionToken<EffectsManager>(
   '@ngneat/effects Effects Manager'
 );

--- a/libs/effects-ng/src/lib/use-directive-effects.spec.ts
+++ b/libs/effects-ng/src/lib/use-directive-effects.spec.ts
@@ -1,9 +1,8 @@
 import { Component, Injectable, Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { createAction, createEffect } from '@ngneat/effects';
+import { Actions, createAction, createEffect } from '@ngneat/effects';
 import { tap } from 'rxjs';
 import { ofType } from 'ts-action-operators';
-import { Actions } from './actions';
 import { provideEffectsManager } from './provide-effects-manager';
 import {
   provideDirectiveEffects,

--- a/libs/effects-ng/src/lib/use-directive-effects.ts
+++ b/libs/effects-ng/src/lib/use-directive-effects.ts
@@ -6,9 +6,8 @@ import {
   Provider,
   InjectionToken,
 } from '@angular/core';
-import { EFFECTS_MANAGER } from './tokens';
 import { getEffectPropsMap } from './utils';
-import { Effect } from '@ngneat/effects';
+import { Effect, EffectsManager } from '@ngneat/effects';
 import {
   isEffectProvided,
   increaseProvidedEffectSources,
@@ -39,7 +38,7 @@ export class EffectsDirective implements OnDestroy {
     self: true,
     optional: true,
   });
-  private readonly manager = inject(EFFECTS_MANAGER, { optional: true });
+  private readonly manager = inject(EffectsManager, { optional: true });
   private readonly sourceInstancesWithProvidersEffectsTokens = new Map<
     any,
     ProvidedEffectToken


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/effects/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently we intentionally create new tokens for providers even if the provider is an existing concept in the core package and there is an available class in the core package to use as an injection token.

This intentional design might bring some benefits, but it might be more beneficial to simply use the existing classes from the core package as injection tokens.

In most cases, the user installs both 
 `@ngneat/effects` and `@ngneat/effects-ng`. When the user hope to inject `Actions`, the first option suggested by the IDE is sometimes the one from `@ngneat/effects` (tested in VS Code), which might cause confusing runtime injection errors as it is not easy to notice.

Besides, this also enables access to the provided `EffectsManager` instance, which can be quite useful when the user wants to create wrappers upon this library, as stated in #66.

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

