### PR TITLE
fix(effects-directive): unregister all effects of a provider

### DIFF
--- a/libs/effects-ng/src/lib/use-directive-effects.spec.ts
+++ b/libs/effects-ng/src/lib/use-directive-effects.spec.ts
@@ -13,13 +13,19 @@ import { provideEffects } from './provide-effects';
 
 const spy = jest.fn();
 const spy2 = jest.fn();
+const spy3 = jest.fn();
 const loadTodos = createAction('[Todos] Load Todos');
 const loadTodos2 = createAction('[Todos] Load Todos 2');
+const loadTodos3 = createAction('[Todos] Load Todos 3');
 
 @Injectable()
 class EffectsOne {
   loadTodos$ = createEffect((actions) =>
     actions.pipe(ofType(loadTodos), tap(spy))
+  );
+
+  loadTodos3$ = createEffect((actions) =>
+    actions.pipe(ofType(loadTodos3), tap(spy3))
   );
 }
 

--- a/libs/effects-ng/src/lib/use-directive-effects.spec.ts
+++ b/libs/effects-ng/src/lib/use-directive-effects.spec.ts
@@ -60,6 +60,7 @@ describe('provideDirectiveEffects & EffectsDirective', () => {
   beforeEach(() => {
     spy.mockClear();
     spy2.mockClear();
+    spy3.mockClear();
   });
 
   it('should provide effects', () => {
@@ -101,6 +102,8 @@ describe('provideDirectiveEffects & EffectsDirective', () => {
     TestBed.createComponent(componentType);
 
     expect(spy).toHaveBeenCalled();
+    expect(spy2).not.toHaveBeenCalled();
+    expect(spy3).not.toHaveBeenCalled();
   });
 
   it('should subscribe on the same effects only once', () => {
@@ -122,6 +125,7 @@ describe('provideDirectiveEffects & EffectsDirective', () => {
 
     expect(spy).toHaveBeenCalledTimes(2);
     expect(spy2).toHaveBeenCalledTimes(1);
+    expect(spy3).not.toHaveBeenCalled();
   });
 
   it('should unsubscribe only from effects that was registered via provideDirectiveEffects when component is destroyed', () => {
@@ -154,25 +158,28 @@ describe('provideDirectiveEffects & EffectsDirective', () => {
     const fixture3 = TestBed.createComponent(TestComponent);
     const actions = TestBed.inject(Actions);
 
-    actions.dispatch(loadTodos2());
+    actions.dispatch(loadTodos2(), loadTodos3());
 
     expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy2).toHaveBeenCalledTimes(1);
     expect(spy2).toHaveBeenCalledTimes(1);
 
     fixture.destroy();
     fixture2.destroy();
 
-    actions.dispatch(loadTodos(), loadTodos2());
+    actions.dispatch(loadTodos(), loadTodos2(), loadTodos3());
 
     expect(spy).toHaveBeenCalledTimes(4);
     expect(spy2).toHaveBeenCalledTimes(2);
+    expect(spy3).toHaveBeenCalledTimes(2);
 
     fixture3.destroy();
 
-    actions.dispatch(loadTodos(), loadTodos2());
+    actions.dispatch(loadTodos(), loadTodos2(), loadTodos3());
 
     expect(spy).toHaveBeenCalledTimes(4);
     expect(spy2).toHaveBeenCalledTimes(3);
+    expect(spy3).toHaveBeenCalledTimes(2);
   });
 
   it('should properly determine source instances and manage their effects', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/effects/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
Ensures correct behavior of directive when on destroy is called

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Only the last (order) effect in a provider was unregistered. 

Issue Number: #72

## What is the new behavior?
All effects are of a provider are unregistered.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
